### PR TITLE
Use window URL to get correct API URL

### DIFF
--- a/public/js/httpController.js
+++ b/public/js/httpController.js
@@ -24,18 +24,13 @@ function replaceCitation(msg, error) {
     }
 }
 
-function getCitation(window) {
-    var data, url;
-
-    url = 'https://boiling-lake-36327.herokuapp.com/v01/citation/';
-    console.log(url);
-
-    data = {
+function getCitation() {
+    var data = {
         style: $('#citationFormat').val(),
         url: $('#citationUrl').val()
     }
 
-    $.post(url, data)
+    $.post(window.location.href.slice(0, window.location.href.indexOf('?')) + '/v01/citation/', data)
         .done(function (returnData) {
             console.log(returnData);
             replaceCitation(returnData.citation);


### PR DESCRIPTION
Uses the window.location object to generate the API URL instead of hard coding it.

As of right now (2017-04-10 16:30 EST) this code is live at https://software-citation.herokuapp.com/

Resolves https://github.com/mozillascience/software-citation-tools/issues/65.